### PR TITLE
[Sprint 130] IFS-4733 sonatype mvn profiles

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -40,8 +40,8 @@ jobs:
     with:
       version: ${{ needs.Version.outputs.next-version }}
       jdk-version: 21
-      maven-opts: '-DaltDeploymentRepository=ossrh::default::https://oss.sonatype.org/content/repositories/snapshots/'
-      deploy-server-id: ossrh
+      maven-opts: '-DaltDeploymentRepository=central::default::https://central.sonatype.org/content/repositories/snapshots/'
+      deploy-server-id: central
       sbom: ${{ startsWith(github.ref, 'refs/heads/release/') }}
       sign: true
       environment: 'Release'

--- a/.github/workflows/maven_release.yml
+++ b/.github/workflows/maven_release.yml
@@ -18,7 +18,7 @@ jobs:
       jdk-version: 21
       version: ${{ github.ref_name }}
       maven-opts: '-P centralRelease'
-      deploy-server-id: ossrh
+      deploy-server-id: central
       sbom: true
       sign: true
       environment: 'Release'

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,30 @@
             <id>centralRelease</id>
             <build>
                 <plugins>
+                    <!-- Avoid SNAPSHOT-versions in releases. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseDeps>
+                                            <message>Keine SNAPSHOT-Abhängigkeiten erlaubt!</message>
+                                        </requireReleaseDeps>
+                                        <requireReleaseVersion>
+                                            <message>Keine SNAPSHOT-Versionen erlaubt!</message>
+                                        </requireReleaseVersion>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -292,14 +292,13 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
 
     <repositories>
         <repository>
-            <id>ossrh-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <id>central-snapshots</id>
+            <url>https://central.sonatype.org/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
* build: IFS-4733 adapts mvn plugin for release
* feat: IFS-4733 enforce no snapshots for release
* refactor: IFS-4733 adapts repository configuration
* refactor: IFS-4733 removes deploy server id
* feat: IFS-4733 uses maven settings for central release